### PR TITLE
feat: bind queue work function argument to a given instance (if any)

### DIFF
--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -1,9 +1,7 @@
-import crypto from "crypto";
-
-import { injectable } from "inversify";
-import Redis from "ioredis";
-
 import { Logger } from "../logging/logger";
+import Redis from "ioredis";
+import crypto from "crypto";
+import { injectable } from "inversify";
 import { retryOnRequest } from "../retry";
 
 function backupKey() {
@@ -75,8 +73,12 @@ export class RedisQueue<T> {
    * @param logger optional logger for tracking jobs
    * @param parallelism how many workers should handle the jobs at any given time
    */
-  async work(f: (t: T) => Promise<void>, logger?: Logger, parallelism = 1) {
+  async work(f: (t: T) => Promise<void>, logger?: Logger, parallelism = 1, instance?: any) {
     let handler: Function;
+    if (instance) {
+      f = f.bind(instance);
+    }
+
     if (logger) {
       handler = wrapHandler(this.name, logger, f);
     } else {

--- a/tests/jobs/helpers/queue.ts
+++ b/tests/jobs/helpers/queue.ts
@@ -2,10 +2,15 @@ export class TestInstance {
   constructor(private city: string, private greetings: string[]) {}
 
   greet(name: string) {
-    return new Promise<void>((resolve, _) => {
-      this.greetings.push(`hello ${this.city}, ${name} is back!`);
-      console.log("THIS IN GREETING", this);
-      resolve();
+    return new Promise<void>((resolve, reject) => {
+      try {
+        this.greetings.push(`hello ${this.city}, ${name} is back!`);
+        console.log("THIS IN GREETING", this);
+        resolve();
+      } catch (err) {
+        console.log("error", err);
+        reject(err);
+      }
     });
   }
 }

--- a/tests/jobs/helpers/queue.ts
+++ b/tests/jobs/helpers/queue.ts
@@ -5,10 +5,8 @@ export class TestInstance {
     return new Promise<void>((resolve, reject) => {
       try {
         this.greetings.push(`hello ${this.city}, ${name} is back!`);
-        console.log("THIS IN GREETING", this);
         resolve();
       } catch (err) {
-        console.log("error", err);
         reject(err);
       }
     });

--- a/tests/jobs/helpers/queue.ts
+++ b/tests/jobs/helpers/queue.ts
@@ -1,0 +1,9 @@
+import { generateSecret } from "jose";
+
+export class TestInstance {
+  constructor(private name: string) {}
+
+  greet(): string {
+    return `${this.name} says hi!`;
+  }
+}

--- a/tests/jobs/helpers/queue.ts
+++ b/tests/jobs/helpers/queue.ts
@@ -1,9 +1,11 @@
-import { generateSecret } from "jose";
-
 export class TestInstance {
-  constructor(private name: string) {}
+  constructor(private city: string, private greetings: string[]) {}
 
-  greet(): string {
-    return `${this.name} says hi!`;
+  greet(name: string) {
+    return new Promise<void>((resolve, _) => {
+      this.greetings.push(`hello ${this.city}, ${name} is back!`);
+      console.log("THIS IN GREETING", this);
+      resolve();
+    });
   }
 }

--- a/tests/jobs/queue.spec.ts
+++ b/tests/jobs/queue.spec.ts
@@ -130,7 +130,7 @@ describe("RedisQueue#work", () => {
     const instance = new TestInstance(city, result);
 
     await altQueue.work(instance.greet);
-    expect(result).to.have.lengthOf(0);
+    expect(result).to.have.lengthOf(5);
   });
 
   it("should bind the worker argument to a specified instance", async () => {

--- a/tests/jobs/queue.spec.ts
+++ b/tests/jobs/queue.spec.ts
@@ -130,7 +130,7 @@ describe("RedisQueue#work", () => {
     const instance = new TestInstance(city, result);
 
     await altQueue.work(instance.greet);
-    expect(result).to.have.lengthOf(5);
+    expect(result).to.have.lengthOf(0);
   });
 
   it("should bind the worker argument to a specified instance", async () => {


### PR DESCRIPTION
## What does this PR do?
Functions supplied as arguments to the `queue.work` method lose their `this` context. This PR helps to address that by binding the function to its corresponding class instance (if specified)