### PR TITLE
feat: poll empty job queues for a duration before backing off

### DIFF
--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -10,8 +10,8 @@ function backupKey() {
   return crypto.randomBytes(16).toString("hex").slice(0, 32);
 }
 
-const JOB_POLL_RETRIES = 3;
-const JOB_POLL_TIMEOUT = "500ms";
+const JOB_POLL_RETRIES = 1;
+const JOB_POLL_TIMEOUT = "3s";
 
 @injectable()
 export class RedisQueue<T> {
@@ -83,7 +83,7 @@ export class RedisQueue<T> {
 
   /**
    * Run the given function on all the items on the queue.
-   * If nothing is on the queue, it will retry on 3 occasions before backing off. This is so slave workers (if any) wait for the master to fill the queue.
+   * If nothing is on the queue, it will retry in 3s before backing off. This is so slave workers (if any) wait for the master to fill the queue.
    * @param f function works on each item
    * @param logger optional logger for tracking jobs
    * @param parallelism how many workers should handle the jobs at any given time

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -120,7 +120,7 @@ export class RedisQueue<T> {
 
         return await Promise.all(work);
       } catch (error) {
-        if (error instanceof RetryError && attempt > JOB_PULL_RETRIES) {
+        if (error instanceof RetryError && attempt >= JOB_PULL_RETRIES) {
           return;
         }
 

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -10,8 +10,8 @@ function backupKey() {
   return crypto.randomBytes(16).toString("hex").slice(0, 32);
 }
 
-const JOB_PULL_RETRIES = 3;
-const JOB_PULL_TIMEOUT = "500ms";
+const JOB_POLL_RETRIES = 3;
+const JOB_POLL_TIMEOUT = "500ms";
 
 @injectable()
 export class RedisQueue<T> {
@@ -89,7 +89,7 @@ export class RedisQueue<T> {
    * @param parallelism how many workers should handle the jobs at any given time
    */
   async work(f: (t: T) => Promise<void>, logger?: Logger, parallelism = 1) {
-    await retryOnRequest(JOB_PULL_RETRIES, JOB_PULL_TIMEOUT, async (attempt: number) => {
+    await retryOnRequest(JOB_POLL_RETRIES, JOB_POLL_TIMEOUT, async (attempt: number) => {
       try {
         let handler: Function;
         if (logger) {
@@ -120,7 +120,7 @@ export class RedisQueue<T> {
 
         return await Promise.all(work);
       } catch (error) {
-        if (error instanceof RetryError && attempt >= JOB_PULL_RETRIES) {
+        if (error instanceof RetryError && attempt >= JOB_POLL_RETRIES) {
           return;
         }
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,15 +1,17 @@
-import crypto from "crypto";
-import { promisify } from "util";
-
-import { Channel } from "amqplib";
-import parser from "cron-parser";
-import ms from "ms";
 import { JSONCodec, JetStreamManager } from "nats";
 import sinon, { SinonFakeTimers } from "sinon";
 
+import { Channel } from "amqplib";
+import crypto from "crypto";
 import { dateReviver } from "../src/strings";
+import ms from "ms";
+import parser from "cron-parser";
+import { promisify } from "util";
 
 let sinonClock: SinonFakeTimers | null;
+Object.defineProperty(global, "performance", {
+  writable: true
+})
 
 /**
  * Generates random HEX string

--- a/tests/jobs/queue.spec.ts
+++ b/tests/jobs/queue.spec.ts
@@ -134,6 +134,7 @@ describe("RedisQueue#work", () => {
 });
 
 describe("RedisQueue#requeue", () => {
+  jest.setTimeout(10000);
   it("should re-process failed jobs", async () => {
     const jobs = Array.from({ length: 10 }).map((_x, i) => i + 1);
     await queue.fill(jobs);

--- a/tests/jobs/queue.spec.ts
+++ b/tests/jobs/queue.spec.ts
@@ -134,7 +134,6 @@ describe("RedisQueue#work", () => {
 });
 
 describe("RedisQueue#requeue", () => {
-  jest.setTimeout(10000);
   it("should re-process failed jobs", async () => {
     const jobs = Array.from({ length: 10 }).map((_x, i) => i + 1);
     await queue.fill(jobs);


### PR DESCRIPTION
Problem: when a job queue is empty, a job runner backs off immediately and won't process any more jobs until the next cron schedule. This is a going to be a problem in a master<>slave situation where a master job runner load jobs into the queue before any processing can start. The slave job runners should be able to wait for a time window to allow for this possibility