### PR TITLE
feat: add gRPC client support to octonet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 octonet is a library that provides utility functions for building microservices such as:
 
-- Interservice communication (via REST)
+- Interservice communication (via REST or gRPC)
 - Subscribing to events from RabbitMQ queues and NATS servers.
 - Logging
 - Distributed Tracing
@@ -67,7 +67,8 @@ yarn upgrade @risemaxi/octonet --latest
 
 Below are links to detailed explanations to the various features of Octonet as well as practical examples:
 
-- [HTTP (Interservice Comunication)](docs/HTTP.md)
+- [HTTP (Interservice Communication)](docs/HTTP.md)
+- [gRPC (Interservice Communication)](docs/GRPC.md)
 - [NatsConsumer (subscribing to Nats topics)](docs/Consumer.md)
 - [QueueManager (subscribing to RabbitMQ queues)](docs/Manager.md)
 - [Authentication](docs/Authentication.md)

--- a/docs/GRPC.md
+++ b/docs/GRPC.md
@@ -1,0 +1,321 @@
+# gRPC (Interservice communication)
+
+This section describes the gRPC module of Octonet and how to use it for interservice communication.
+
+## About
+
+The gRPC module provides a type-safe, fluent client for making [gRPC](https://grpc.io/) calls between services. It is designed as a drop-in companion to the HTTP module — both share the same auth, tracing, and builder patterns so switching between them is straightforward.
+
+Use the gRPC module when:
+
+- You need lower latency and smaller payloads than REST for high-frequency interservice calls
+- You want a strict, schema-first contract between services via `.proto` files
+- You are migrating an existing HTTP interservice client to gRPC
+
+## Prerequisites
+
+Install the required peer dependencies alongside Octonet:
+
+```bash
+yarn add @grpc/grpc-js @grpc/proto-loader
+```
+
+You will also need a `.proto` file that defines the service contract. Both the calling service and the receiving service must use the same file.
+
+---
+
+## GrpcAgent
+
+`GrpcAgent` is the entry point for all gRPC calls. It is analogous to `HttpAgent` — configure it once with your service's auth details and bind it to your DI container. A single instance can call any number of downstream gRPC services.
+
+### Constructor
+
+```ts
+new GrpcAgent(config: AgentConfig)
+```
+
+#### Parameters
+
+| Field | Type | Description |
+|---|---|---|
+| `service` | `string` | Name of the calling service |
+| `scheme` | `string` | Auth token scheme, e.g. `"Rise"` |
+| `secret` | `string` | Secret used to sign system JWTs |
+| `timeout` | `string` | JWT expiry for system tokens. Defaults to `"10s"` |
+
+#### Stub caching
+
+`GrpcAgent` creates gRPC stubs (channels) lazily — the first call to a given `(address, protoPath, service)` combination loads the proto file and opens the channel. Every subsequent call to the same target reuses the cached stub, so the overhead is paid at most once per unique connection target.
+
+### `call(method, payload)`
+
+Prepares a gRPC call and returns a `GrpcRequestWrapper` for attaching connection info, auth, and tracing before executing.
+
+```ts
+agent.call(method: string, payload: object): GrpcRequestWrapper
+```
+
+#### Parameters
+
+- **method** — RPC method name as defined in the proto service, e.g. `"GetUser"`
+- **payload** — Request message matching the proto message type
+
+---
+
+## GrpcRequestWrapper
+
+`GrpcRequestWrapper` is a fluent builder returned by `agent.call()`. Chain methods to configure the call, then execute it with `.do()`.
+
+### `.via(address, protoPath, service, credentials?)`
+
+Specifies the target gRPC server. **Required** — must be called before `.do()`.
+
+```ts
+.via(
+  address: string,           // host:port, e.g. "users-service:50051"
+  protoPath: string,         // absolute path to the .proto file
+  service: string,           // fully qualified service name, e.g. "users.UserService"
+  credentials?: ChannelCredentials  // defaults to insecure (suitable for in-cluster traffic)
+): this
+```
+
+### `.auth(reqOrSession?)`
+
+Attaches an authorization token to the call metadata. Supports three modes:
+
+| Call | Behaviour |
+|---|---|
+| `.auth(req)` | Forwards the `Authorization` header from an Express request |
+| `.auth(session)` | Generates a signed system JWT containing the given session payload |
+| `.auth()` | Generates a signed system JWT scoped to the calling service |
+
+### `.track(req?)`
+
+Enables distributed tracing on the call.
+
+| Call | Behaviour |
+|---|---|
+| `.track(req)` | Forwards `x-request-id` from an Express request |
+| `.track()` | Generates a new UUID as `x-request-id` |
+
+In both cases, `x-origin-service` is set to the calling service name.
+
+### `.set(key, value)`
+
+Sets an arbitrary metadata key/value pair on the call.
+
+```ts
+.set(key: string, value: string): this
+```
+
+### `.do(deadline?)`
+
+Executes the RPC call. Always the final method in the chain.
+
+```ts
+.do<TResponse = any>(deadline?: number): Promise<TResponse>
+```
+
+- **deadline** — timeout in seconds. Defaults to `30`.
+- Rejects with `GrpcError` if the server returns a non-OK status or the deadline is exceeded.
+
+---
+
+## GrpcError
+
+`GrpcError` is thrown whenever a gRPC call returns a non-OK status. It is analogous to `APIError` in the HTTP module.
+
+| Property | Type | Description |
+|---|---|---|
+| `message` | `string` | Human-readable summary including service, method, status name, and details |
+| `code` | `grpc.status` | Numeric gRPC status code |
+| `details` | `string` | Error detail string from the server |
+
+Common gRPC status codes:
+
+| Code | Name | Typical cause |
+|---|---|---|
+| `1` | `CANCELLED` | Call cancelled by the client |
+| `4` | `DEADLINE_EXCEEDED` | Call did not complete before the deadline |
+| `5` | `NOT_FOUND` | Requested resource does not exist |
+| `7` | `PERMISSION_DENIED` | Caller is not authorised |
+| `13` | `INTERNAL` | Unhandled error on the server |
+| `14` | `UNAVAILABLE` | Server is down or unreachable |
+
+---
+
+## Practical example
+
+### Step 1: define the proto contract
+
+Create a `.proto` file that describes the service. Both the client and server must use the same file.
+
+```proto
+// src/core/users/user.proto
+
+syntax = "proto3";
+package users;
+
+service UserService {
+  rpc GetUser (GetUserRequest) returns (UserResponse);
+}
+
+message GetUserRequest {
+  string id = 1;
+}
+
+message UserResponse {
+  string id          = 1;
+  string first_name  = 2;
+  string last_name   = 3;
+  string email       = 4;
+}
+```
+
+### Step 2: add the gRPC URL to your env config
+
+```ts
+// src/config/env.ts
+
+export interface Env {
+  service_name: string;
+  auth_scheme: string;
+  service_secret: string;
+  users_grpc_url: string; // e.g. "users-service:50051"
+}
+```
+
+### Step 3: bind GrpcAgent to your DI container
+
+Bind a single `GrpcAgent` instance so it is shared — and its stub cache is shared — across all clients in the service.
+
+```ts
+// src/config/container.ts
+
+import { Container } from "inversify";
+import { GrpcAgent } from "@risemaxi/octonet";
+import { TYPES } from "./types";
+import { env } from "./env";
+
+const container = new Container();
+
+container
+  .bind<GrpcAgent>(TYPES.GrpcAgent)
+  .toConstantValue(
+    new GrpcAgent({
+      service: env.service_name,
+      scheme: env.auth_scheme,
+      secret: env.service_secret,
+    })
+  );
+
+export { container };
+```
+
+### Step 4: use the agent in a client class
+
+```ts
+// src/core/users/user.grpc-client.ts
+
+import path from "path";
+import { inject, injectable } from "inversify";
+import { GrpcAgent, GrpcError } from "@risemaxi/octonet";
+import { Request } from "express";
+import { TYPES } from "../../config/types";
+import { env } from "../../config/env";
+
+const PROTO_PATH = path.join(__dirname, "user.proto");
+
+interface User {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+}
+
+@injectable()
+export class UserGrpcClient {
+  constructor(@inject(TYPES.GrpcAgent) private readonly agent: GrpcAgent) {}
+
+  getUser(id: string, req: Request): Promise<User> {
+    return this.agent
+      .call("GetUser", { id })
+      .via(env.users_grpc_url, PROTO_PATH, "users.UserService")
+      .auth(req)
+      .track(req)
+      .do<User>(60);
+  }
+}
+```
+
+### Step 5: handle errors
+
+```ts
+import { GrpcError } from "@risemaxi/octonet";
+import * as grpc from "@grpc/grpc-js";
+
+try {
+  const user = await userGrpcClient.getUser(id, req);
+} catch (error) {
+  if (error instanceof GrpcError) {
+    switch (error.code) {
+      case grpc.status.NOT_FOUND:
+        // resource does not exist on the server
+        throw new NotFoundError(`User ${id} not found`);
+
+      case grpc.status.DEADLINE_EXCEEDED:
+        // call timed out
+        throw new TimeoutError(`users/GetUser timed out`);
+
+      case grpc.status.UNAVAILABLE:
+        // server is down or unreachable
+        throw new ServiceUnavailableError("Users service is unavailable");
+
+      default:
+        throw error;
+    }
+  }
+
+  throw error;
+}
+```
+
+---
+
+## Making headless (system-to-system) calls
+
+When a call is not initiated by a user request — for example inside a background job — omit the Express request from `.auth()` and `.track()`. Octonet will generate a system JWT scoped to the calling service and a fresh trace ID automatically.
+
+```ts
+// inside a background job or event handler
+const user = await this.agent
+  .call("GetUser", { id })
+  .via(env.users_grpc_url, PROTO_PATH, "users.UserService")
+  .auth()    // generates system JWT — no Express request needed
+  .track()   // generates a fresh x-request-id
+  .do<User>(60);
+```
+
+---
+
+## Copying proto files at build time
+
+Proto files live in `src/` alongside your TypeScript source but must also be present in `dist/` at runtime. Add the following `rsync` command to your build script so all `.proto` files are copied automatically — including any new ones added in the future.
+
+```json
+// package.json
+{
+  "scripts": {
+    "build": "tsc -p ./tsconfig.json && rsync -a --include='*.proto' --include='*/' --exclude='*' src/ dist/"
+  }
+}
+```
+
+---
+
+## References
+
+- [gRPC concepts](https://grpc.io/docs/what-is-grpc/core-concepts/)
+- [Protocol Buffers language guide](https://protobuf.dev/programming-guides/proto3/)
+- [@grpc/grpc-js](https://github.com/grpc/grpc-node/tree/master/packages/grpc-js)
+- [@grpc/proto-loader](https://github.com/grpc/grpc-node/tree/master/packages/proto-loader)

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.14.3",
+    "@grpc/proto-loader": "^0.8.0",
     "amqplib": "^0.10.3",
     "axios": "^1.2.3",
     "bunyan": "^1.8.15",

--- a/src/grpc/agent.ts
+++ b/src/grpc/agent.ts
@@ -5,37 +5,6 @@ import { AgentConfig } from "../http/agent";
 import { AuthConfig } from "../http/wrapper";
 import { GrpcRequestWrapper } from "./wrapper";
 
-export interface GrpcAgentConfig {
-  /**
-   * gRPC server address — host:port.
-   * @example "localhost:50051"
-   */
-  address: string;
-
-  /**
-   * Absolute path to the .proto file defining the service.
-   */
-  protoPath: string;
-
-  /**
-   * Fully qualified service name in the proto package.
-   * @example "users.UserService"
-   */
-  service: string;
-
-  /**
-   * gRPC channel credentials. Defaults to insecure (suitable for
-   * internal cluster traffic). Pass `grpc.credentials.createSsl()`
-   * for TLS.
-   */
-  credentials?: grpc.ChannelCredentials;
-
-  /**
-   * proto-loader options. Defaults match the standard gRPC-js recommendations.
-   */
-  loaderOptions?: protoLoader.Options;
-}
-
 const DEFAULT_LOADER_OPTIONS: protoLoader.Options = {
   keepCase: true,
   longs: String,
@@ -47,67 +16,94 @@ const DEFAULT_LOADER_OPTIONS: protoLoader.Options = {
 /**
  * Resolves a nested path like "users.UserService" on the loaded proto object.
  */
-function resolveService(proto: Record<string, any>, path: string): any {
-  return path.split(".").reduce((obj, key) => obj?.[key], proto);
+function resolveService(proto: Record<string, any>, servicePath: string): any {
+  return servicePath.split(".").reduce((obj, key) => obj?.[key], proto);
 }
 
 /**
  * gRPC client agent. Analogous to `HttpAgent` — configure once, use everywhere.
  *
- * Loads the proto file and creates the service stub on construction so the
- * overhead is paid once, not on every call.
+ * Accepts only auth config at construction time. The target service address and
+ * proto file are specified per-call via `.via()`, keeping the agent reusable
+ * across any number of downstream gRPC services.
+ *
+ * Stubs are created lazily and cached by (address, protoPath, service) so the
+ * proto-loading and channel-creation overhead is paid at most once per unique
+ * connection target.
  *
  * @example
- * const grpcAgent = new GrpcAgent(
- *   { service: "rise-moneyio", scheme: env.auth_scheme, secret: env.service_secret },
- *   { address: env.users_grpc_url, protoPath: path.join(__dirname, "user.proto"), service: "users.UserService" }
- * );
+ * const grpcAgent = new GrpcAgent({
+ *   service: "rise-moneyio",
+ *   scheme: env.auth_scheme,
+ *   secret: env.service_secret
+ * });
  *
- * // usage
  * const user = await grpcAgent
  *   .call("GetUser", { id })
+ *   .via(env.users_grpc_url, path.join(__dirname, "user.proto"), "users.UserService")
  *   .auth()
  *   .track(req)
  *   .do<User>(60);
  */
 export class GrpcAgent {
-  private readonly stub: any;
+  private readonly stubCache = new Map<string, any>();
   private readonly authConfig: AuthConfig;
   private readonly serviceName: string;
 
-  constructor(agentConfig: AgentConfig, grpcConfig: GrpcAgentConfig) {
-    const loaderOptions = { ...DEFAULT_LOADER_OPTIONS, ...grpcConfig.loaderOptions };
-    const packageDef = protoLoader.loadSync(grpcConfig.protoPath, loaderOptions);
-    const proto = grpc.loadPackageDefinition(packageDef) as Record<string, any>;
-
-    const ServiceConstructor = resolveService(proto, grpcConfig.service);
-    if (!ServiceConstructor) {
-      throw new Error(`Service "${grpcConfig.service}" not found in proto file: ${grpcConfig.protoPath}`);
-    }
-
-    const credentials = grpcConfig.credentials ?? grpc.credentials.createInsecure();
-    this.stub = new ServiceConstructor(grpcConfig.address, credentials);
-
+  constructor(agentConfig: AgentConfig) {
     this.authConfig = {
       secret: new TextEncoder().encode(agentConfig.secret),
       scheme: agentConfig.scheme,
       timeout: agentConfig.timeout ?? "10s"
     };
-
     this.serviceName = agentConfig.service;
   }
 
   /**
    * Prepare a gRPC call. Returns a fluent `GrpcRequestWrapper` for
-   * attaching auth, tracing, and executing the call.
+   * attaching connection info, auth, tracing, and executing the call.
    *
    * @param method RPC method name as defined in the proto service.
    * @param payload Request message payload.
    *
    * @example
-   * grpcAgent.call("GetUser", { id }).auth().track(req).do<User>(60)
+   * grpcAgent
+   *   .call("GetUser", { id })
+   *   .via(env.users_grpc_url, protoPath, "users.UserService")
+   *   .auth()
+   *   .track(req)
+   *   .do<User>(60)
    */
   call<TR extends object = any>(method: string, payload: TR): GrpcRequestWrapper<TR> {
-    return new GrpcRequestWrapper(this.stub, this.serviceName, this.authConfig, method, payload);
+    return new GrpcRequestWrapper(
+      (address, protoPath, service, credentials) =>
+        this.resolveStub(address, protoPath, service, credentials),
+      this.serviceName,
+      this.authConfig,
+      method,
+      payload
+    );
+  }
+
+  private resolveStub(
+    address: string,
+    protoPath: string,
+    service: string,
+    credentials?: grpc.ChannelCredentials
+  ): any {
+    const key = `${address}\0${protoPath}\0${service}`;
+
+    if (!this.stubCache.has(key)) {
+      const packageDef = protoLoader.loadSync(protoPath, DEFAULT_LOADER_OPTIONS);
+      const proto = grpc.loadPackageDefinition(packageDef) as Record<string, any>;
+      const ServiceConstructor = resolveService(proto, service);
+      if (!ServiceConstructor) {
+        throw new Error(`Service "${service}" not found in proto file: ${protoPath}`);
+      }
+      const creds = credentials ?? grpc.credentials.createInsecure();
+      this.stubCache.set(key, new ServiceConstructor(address, creds));
+    }
+
+    return this.stubCache.get(key)!;
   }
 }

--- a/src/grpc/agent.ts
+++ b/src/grpc/agent.ts
@@ -1,0 +1,113 @@
+import * as grpc from "@grpc/grpc-js";
+import * as protoLoader from "@grpc/proto-loader";
+
+import { AgentConfig } from "../http/agent";
+import { AuthConfig } from "../http/wrapper";
+import { GrpcRequestWrapper } from "./wrapper";
+
+export interface GrpcAgentConfig {
+  /**
+   * gRPC server address — host:port.
+   * @example "localhost:50051"
+   */
+  address: string;
+
+  /**
+   * Absolute path to the .proto file defining the service.
+   */
+  protoPath: string;
+
+  /**
+   * Fully qualified service name in the proto package.
+   * @example "users.UserService"
+   */
+  service: string;
+
+  /**
+   * gRPC channel credentials. Defaults to insecure (suitable for
+   * internal cluster traffic). Pass `grpc.credentials.createSsl()`
+   * for TLS.
+   */
+  credentials?: grpc.ChannelCredentials;
+
+  /**
+   * proto-loader options. Defaults match the standard gRPC-js recommendations.
+   */
+  loaderOptions?: protoLoader.Options;
+}
+
+const DEFAULT_LOADER_OPTIONS: protoLoader.Options = {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+};
+
+/**
+ * Resolves a nested path like "users.UserService" on the loaded proto object.
+ */
+function resolveService(proto: Record<string, any>, path: string): any {
+  return path.split(".").reduce((obj, key) => obj?.[key], proto);
+}
+
+/**
+ * gRPC client agent. Analogous to `HttpAgent` — configure once, use everywhere.
+ *
+ * Loads the proto file and creates the service stub on construction so the
+ * overhead is paid once, not on every call.
+ *
+ * @example
+ * const grpcAgent = new GrpcAgent(
+ *   { service: "rise-moneyio", scheme: env.auth_scheme, secret: env.service_secret },
+ *   { address: env.users_grpc_url, protoPath: path.join(__dirname, "user.proto"), service: "users.UserService" }
+ * );
+ *
+ * // usage
+ * const user = await grpcAgent
+ *   .call("GetUser", { id })
+ *   .auth()
+ *   .track(req)
+ *   .do<User>(60);
+ */
+export class GrpcAgent {
+  private readonly stub: any;
+  private readonly authConfig: AuthConfig;
+  private readonly serviceName: string;
+
+  constructor(agentConfig: AgentConfig, grpcConfig: GrpcAgentConfig) {
+    const loaderOptions = { ...DEFAULT_LOADER_OPTIONS, ...grpcConfig.loaderOptions };
+    const packageDef = protoLoader.loadSync(grpcConfig.protoPath, loaderOptions);
+    const proto = grpc.loadPackageDefinition(packageDef) as Record<string, any>;
+
+    const ServiceConstructor = resolveService(proto, grpcConfig.service);
+    if (!ServiceConstructor) {
+      throw new Error(`Service "${grpcConfig.service}" not found in proto file: ${grpcConfig.protoPath}`);
+    }
+
+    const credentials = grpcConfig.credentials ?? grpc.credentials.createInsecure();
+    this.stub = new ServiceConstructor(grpcConfig.address, credentials);
+
+    this.authConfig = {
+      secret: new TextEncoder().encode(agentConfig.secret),
+      scheme: agentConfig.scheme,
+      timeout: agentConfig.timeout ?? "10s"
+    };
+
+    this.serviceName = agentConfig.service;
+  }
+
+  /**
+   * Prepare a gRPC call. Returns a fluent `GrpcRequestWrapper` for
+   * attaching auth, tracing, and executing the call.
+   *
+   * @param method RPC method name as defined in the proto service.
+   * @param payload Request message payload.
+   *
+   * @example
+   * grpcAgent.call("GetUser", { id }).auth().track(req).do<User>(60)
+   */
+  call<TR extends object = any>(method: string, payload: TR): GrpcRequestWrapper<TR> {
+    return new GrpcRequestWrapper(this.stub, this.serviceName, this.authConfig, method, payload);
+  }
+}

--- a/src/grpc/errors.ts
+++ b/src/grpc/errors.ts
@@ -1,0 +1,16 @@
+import * as grpc from "@grpc/grpc-js";
+
+/**
+ * Thrown when a gRPC call returns a non-OK status.
+ * Analogous to `APIError` in the HTTP module.
+ */
+export class GrpcError extends Error {
+  readonly code: grpc.status;
+  readonly details: string;
+
+  constructor(service: string, method: string, err: grpc.ServiceError) {
+    super(`gRPC call ${service}/${method} failed with status ${grpc.status[err.code]}: ${err.details}`);
+    this.code = err.code;
+    this.details = err.details;
+  }
+}

--- a/src/grpc/index.ts
+++ b/src/grpc/index.ts
@@ -1,0 +1,3 @@
+export * from "./agent";
+export * from "./errors";
+export * from "./wrapper";

--- a/src/grpc/wrapper.ts
+++ b/src/grpc/wrapper.ts
@@ -40,7 +40,7 @@ export class GrpcRequestWrapper<TRequest extends object> {
   }
 
   /**
-   * Attach authorisation metadata to the call.
+   * Attach authorization metadata to the call.
    *
    * - `auth(req)` — forwards the Authorization header from an Express request.
    * - `auth(session)` — generates a system JWT from a session/payload object.
@@ -51,7 +51,12 @@ export class GrpcRequestWrapper<TRequest extends object> {
 
     if (isExpressReq) {
       const authHeader = (reqOrSession as Request).headers.authorization;
-      if (authHeader) this.metadata.set("authorization", authHeader);
+      if (!authHeader) {
+        throw new Error(
+          `gRPC call ${this.service}/${this.method} requires an authorization token`
+        );
+      }
+      this.metadata.set("authorization", authHeader);
       return this;
     }
 
@@ -95,6 +100,10 @@ export class GrpcRequestWrapper<TRequest extends object> {
     const callOptions: grpc.CallOptions = {
       deadline: new Date(Date.now() + deadline * 1000)
     };
+
+    if (typeof this.stub[this.method] !== "function") {
+      throw new Error(`gRPC method "${this.method}" does not exist on stub for service "${this.service}"`);
+    }
 
     return new Promise<TResponse>((resolve, reject) => {
       this.stub[this.method](

--- a/src/grpc/wrapper.ts
+++ b/src/grpc/wrapper.ts
@@ -1,11 +1,21 @@
 import * as grpc from "@grpc/grpc-js";
-
-import { Action, AuthConfig } from "../http/wrapper";
-
-import { GrpcError } from "./errors";
 import { Request } from "express";
-import { encode } from "../http/jwt";
 import { v4 as uuidv4 } from "uuid";
+
+import { encode } from "../http/jwt";
+import { Action, AuthConfig } from "../http/wrapper";
+import { GrpcError } from "./errors";
+
+/**
+ * Resolves a gRPC stub for a given connection target.
+ * Provided by `GrpcAgent`, which caches stubs to avoid repeated proto loading.
+ */
+export type StubResolver = (
+  address: string,
+  protoPath: string,
+  service: string,
+  credentials?: grpc.ChannelCredentials
+) => any;
 
 /**
  * Fluent request builder for a single gRPC call.
@@ -14,6 +24,7 @@ import { v4 as uuidv4 } from "uuid";
  * @example
  * const user = await grpcAgent
  *   .call("GetUser", { id })
+ *   .via(env.users_grpc_url, path.join(__dirname, "user.proto"), "users.UserService")
  *   .auth()
  *   .track(req)
  *   .do<User>(60);
@@ -21,21 +32,36 @@ import { v4 as uuidv4 } from "uuid";
 export class GrpcRequestWrapper<TRequest extends object> {
   private metadata = new grpc.Metadata();
   private asyncActions: Action[] = [];
+  private connection?: {
+    address: string;
+    protoPath: string;
+    service: string;
+    credentials?: grpc.ChannelCredentials;
+  };
 
   constructor(
-    private readonly stub: any,
-    private readonly service: string,
+    private readonly resolveStub: StubResolver,
+    private readonly serviceName: string,
     private readonly authConfig: AuthConfig,
     private readonly method: string,
     private readonly payload: TRequest
   ) {}
 
-  /**
-   * Push async work to run just before the call is made,
-   * keeping the builder API synchronous.
-   */
   private defer(action: Action): this {
     this.asyncActions.push(action);
+    return this;
+  }
+
+  /**
+   * Specify the gRPC server to call.
+   *
+   * @param address gRPC server address — host:port.
+   * @param protoPath Absolute path to the .proto file defining the service.
+   * @param service Fully qualified service name, e.g. "users.UserService".
+   * @param credentials Channel credentials. Defaults to insecure.
+   */
+  via(address: string, protoPath: string, service: string, credentials?: grpc.ChannelCredentials): this {
+    this.connection = { address, protoPath, service, credentials };
     return this;
   }
 
@@ -52,15 +78,13 @@ export class GrpcRequestWrapper<TRequest extends object> {
     if (isExpressReq) {
       const authHeader = (reqOrSession as Request).headers.authorization;
       if (!authHeader) {
-        throw new Error(
-          `gRPC call ${this.service}/${this.method} requires an authorization token`
-        );
+        throw new Error(`gRPC call ${this.serviceName}/${this.method} requires an authorization token`);
       }
       this.metadata.set("authorization", authHeader);
       return this;
     }
 
-    const session = reqOrSession ?? { service: this.service, request_time: new Date() };
+    const session = reqOrSession ?? { service: this.serviceName, request_time: new Date() };
 
     return this.defer(async () => {
       const token = await encode(this.authConfig.secret, this.authConfig.timeout, session);
@@ -76,12 +100,12 @@ export class GrpcRequestWrapper<TRequest extends object> {
   track(req?: Request): this {
     const requestId = req?.headers["x-request-id"] as string | undefined;
     this.metadata.set("x-request-id", requestId ?? uuidv4());
-    this.metadata.set("x-origin-service", this.service);
+    this.metadata.set("x-origin-service", this.serviceName);
     return this;
   }
 
   /**
-   * Set additional metadata key/value pairs.
+   * Set an additional metadata key/value pair.
    */
   set(key: string, value: string): this {
     this.metadata.set(key, value);
@@ -90,30 +114,45 @@ export class GrpcRequestWrapper<TRequest extends object> {
 
   /**
    * Execute the RPC call.
+   *
    * @param deadline timeout in seconds (default: 30)
    */
   async do<TResponse = any>(deadline = 30): Promise<TResponse> {
+    if (!this.connection) {
+      throw new Error(
+        `No connection specified for gRPC call ${this.serviceName}/${this.method}. ` +
+          `Call .via(address, protoPath, service) before .do()`
+      );
+    }
+
     for (const action of this.asyncActions) {
       await action();
+    }
+
+    const stub = this.resolveStub(
+      this.connection.address,
+      this.connection.protoPath,
+      this.connection.service,
+      this.connection.credentials
+    );
+
+    if (typeof stub[this.method] !== "function") {
+      throw new Error(
+        `gRPC method "${this.method}" does not exist on stub for service "${this.serviceName}"`
+      );
     }
 
     const callOptions: grpc.CallOptions = {
       deadline: new Date(Date.now() + deadline * 1000)
     };
 
-    if (typeof this.stub[this.method] !== "function") {
-      throw new Error(`gRPC method "${this.method}" does not exist on stub for service "${this.service}"`);
-    }
-
     return new Promise<TResponse>((resolve, reject) => {
-      this.stub[this.method](
+      stub[this.method](
         this.payload,
         this.metadata,
         callOptions,
         (err: grpc.ServiceError | null, response: TResponse) => {
-          if (err) {
-            return reject(new GrpcError(this.service, this.method, err));
-          }
+          if (err) return reject(new GrpcError(this.serviceName, this.method, err));
           resolve(response);
         }
       );

--- a/src/grpc/wrapper.ts
+++ b/src/grpc/wrapper.ts
@@ -1,0 +1,111 @@
+import * as grpc from "@grpc/grpc-js";
+
+import { Action, AuthConfig } from "../http/wrapper";
+
+import { GrpcError } from "./errors";
+import { Request } from "express";
+import { encode } from "../http/jwt";
+import { v4 as uuidv4 } from "uuid";
+
+/**
+ * Fluent request builder for a single gRPC call.
+ * Mirrors `RequestWrapper` from the HTTP module.
+ *
+ * @example
+ * const user = await grpcAgent
+ *   .call("GetUser", { id })
+ *   .auth()
+ *   .track(req)
+ *   .do<User>(60);
+ */
+export class GrpcRequestWrapper<TRequest extends object> {
+  private metadata = new grpc.Metadata();
+  private asyncActions: Action[] = [];
+
+  constructor(
+    private readonly stub: any,
+    private readonly service: string,
+    private readonly authConfig: AuthConfig,
+    private readonly method: string,
+    private readonly payload: TRequest
+  ) {}
+
+  /**
+   * Push async work to run just before the call is made,
+   * keeping the builder API synchronous.
+   */
+  private defer(action: Action): this {
+    this.asyncActions.push(action);
+    return this;
+  }
+
+  /**
+   * Attach authorisation metadata to the call.
+   *
+   * - `auth(req)` — forwards the Authorization header from an Express request.
+   * - `auth(session)` — generates a system JWT from a session/payload object.
+   * - `auth()` — generates a system JWT scoped to the calling service.
+   */
+  auth(reqOrSession?: Request | Record<string, any>): this {
+    const isExpressReq = reqOrSession && "headers" in reqOrSession;
+
+    if (isExpressReq) {
+      const authHeader = (reqOrSession as Request).headers.authorization;
+      if (authHeader) this.metadata.set("authorization", authHeader);
+      return this;
+    }
+
+    const session = reqOrSession ?? { service: this.service, request_time: new Date() };
+
+    return this.defer(async () => {
+      const token = await encode(this.authConfig.secret, this.authConfig.timeout, session);
+      this.metadata.set("authorization", `${this.authConfig.scheme} ${token}`);
+    });
+  }
+
+  /**
+   * Enable distributed tracing on the call.
+   * Forwards x-request-id from an Express request, or generates a new one.
+   * Also sets x-origin-service so the receiver knows where the call came from.
+   */
+  track(req?: Request): this {
+    const requestId = req?.headers["x-request-id"] as string | undefined;
+    this.metadata.set("x-request-id", requestId ?? uuidv4());
+    this.metadata.set("x-origin-service", this.service);
+    return this;
+  }
+
+  /**
+   * Set additional metadata key/value pairs.
+   */
+  set(key: string, value: string): this {
+    this.metadata.set(key, value);
+    return this;
+  }
+
+  /**
+   * Execute the RPC call.
+   * @param deadline timeout in seconds (default: 30)
+   */
+  async do<TResponse = any>(deadline = 30): Promise<TResponse> {
+    for (const action of this.asyncActions) {
+      await action();
+    }
+
+    const callOptions: grpc.CallOptions = {
+      deadline: new Date(Date.now() + deadline * 1000)
+    };
+
+    return new Promise<TResponse>((resolve, reject) => {
+      this.stub[this.method](
+        this.payload,
+        this.metadata,
+        callOptions,
+        (err: grpc.ServiceError | null, response: TResponse) => {
+          if (err) return reject(new GrpcError(this.service, this.method, err));
+          resolve(response);
+        }
+      );
+    });
+  }
+}

--- a/src/grpc/wrapper.ts
+++ b/src/grpc/wrapper.ts
@@ -102,7 +102,9 @@ export class GrpcRequestWrapper<TRequest extends object> {
         this.metadata,
         callOptions,
         (err: grpc.ServiceError | null, response: TResponse) => {
-          if (err) return reject(new GrpcError(this.service, this.method, err));
+          if (err) {
+            return reject(new GrpcError(this.service, this.method, err));
+          }
           resolve(response);
         }
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,4 @@ export { ExitError, RetryError, retryOnError, retryOnRequest } from "./retry";
 export * from "./tokens/redis.store";
 export * from "./tokens/store";
 export * from "./tracing";
+export * from "./grpc";

--- a/tests/grpc/agent.spec.ts
+++ b/tests/grpc/agent.spec.ts
@@ -1,21 +1,25 @@
 import * as grpc from "@grpc/grpc-js";
-
-import { EchoResponse, startGrpcServer, stopGrpcServer } from "./server";
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import path from "path";
 
 import { GrpcAgent } from "../../src/grpc/agent";
 import { GrpcRequestWrapper } from "../../src/grpc/wrapper";
-import { expect } from "chai";
-import path from "path";
 import { randomString } from "../helpers";
+import { EchoResponse, startGrpcServer, stopGrpcServer } from "./server";
+
+chai.use(chaiAsPromised);
 
 const PROTO_PATH = path.join(__dirname, "test.proto");
 const agentConfig = { service: "test_service", scheme: "Test", secret: randomString(32) };
 
 let grpcServer: grpc.Server;
-let port: number;
+let serverAddress: string;
 
 beforeAll(async () => {
+  let port: number;
   [grpcServer, port] = await startGrpcServer();
+  serverAddress = `localhost:${port}`;
 });
 
 afterAll(async () => {
@@ -23,26 +27,8 @@ afterAll(async () => {
 });
 
 describe("GrpcAgent constructor", () => {
-  it("should throw when the service is not found in the proto", () => {
-    expect(
-      () =>
-        new GrpcAgent(agentConfig, {
-          address: `localhost:${port}`,
-          protoPath: PROTO_PATH,
-          service: "test.NonExistent"
-        })
-    ).to.throw(/NonExistent.+not found/);
-  });
-
-  it("should construct successfully with a valid service path", () => {
-    expect(
-      () =>
-        new GrpcAgent(agentConfig, {
-          address: `localhost:${port}`,
-          protoPath: PROTO_PATH,
-          service: "test.TestService"
-        })
-    ).to.not.throw();
+  it("should construct with only auth config", () => {
+    expect(() => new GrpcAgent(agentConfig)).to.not.throw();
   });
 });
 
@@ -50,11 +36,7 @@ describe("GrpcAgent#call", () => {
   let agent: GrpcAgent;
 
   beforeAll(() => {
-    agent = new GrpcAgent(agentConfig, {
-      address: `localhost:${port}`,
-      protoPath: PROTO_PATH,
-      service: "test.TestService"
-    });
+    agent = new GrpcAgent(agentConfig);
   });
 
   it("should return a GrpcRequestWrapper", () => {
@@ -62,25 +44,67 @@ describe("GrpcAgent#call", () => {
     expect(wrapper).to.be.instanceOf(GrpcRequestWrapper);
   });
 
+  it("should reject on .do() when the service is not found in the proto", async () => {
+    await expect(
+      agent.call("Echo", { message: "hello" }).via(serverAddress, PROTO_PATH, "test.NonExistent").do()
+    ).to.be.rejectedWith(/NonExistent.+not found/);
+  });
+
   it("should execute an RPC end-to-end", async () => {
-    const res = await agent.call("Echo", { message: "grpc-agent" }).do<EchoResponse>();
+    const res = await agent
+      .call("Echo", { message: "grpc-agent" })
+      .via(serverAddress, PROTO_PATH, "test.TestService")
+      .do<EchoResponse>();
+
     expect(res.message).to.eq("grpc-agent");
   });
 
   it("should execute an authenticated call end-to-end", async () => {
-    const res = await agent.call("Echo", { message: "auth-test" }).auth().do<EchoResponse>();
+    const res = await agent
+      .call("Echo", { message: "auth-test" })
+      .via(serverAddress, PROTO_PATH, "test.TestService")
+      .auth()
+      .do<EchoResponse>();
+
     expect(res.authorization).to.match(/^Test\s.+/);
   });
 
   it("should execute a tracked call end-to-end", async () => {
-    const res = await agent.call("Echo", { message: "track-test" }).track().do<EchoResponse>();
+    const res = await agent
+      .call("Echo", { message: "track-test" })
+      .via(serverAddress, PROTO_PATH, "test.TestService")
+      .track()
+      .do<EchoResponse>();
+
     expect(res.request_id).to.be.a("string").with.length(36);
     expect(res.origin_service).to.eq(agentConfig.service);
   });
 
   it("should chain auth and track together", async () => {
-    const res = await agent.call("Echo", { message: "chained" }).auth().track().do<EchoResponse>();
+    const res = await agent
+      .call("Echo", { message: "chained" })
+      .via(serverAddress, PROTO_PATH, "test.TestService")
+      .auth()
+      .track()
+      .do<EchoResponse>();
+
     expect(res.authorization).to.match(/^Test\s.+/);
     expect(res.request_id).to.be.a("string").with.length(36);
+  });
+
+  it("should cache the stub and reuse it across calls", async () => {
+    const [res1, res2] = await Promise.all([
+      agent
+        .call("Echo", { message: "first" })
+        .via(serverAddress, PROTO_PATH, "test.TestService")
+        .do<EchoResponse>(),
+      agent
+        .call("Echo", { message: "second" })
+        .via(serverAddress, PROTO_PATH, "test.TestService")
+        .do<EchoResponse>()
+    ]);
+
+    expect(res1.message).to.eq("first");
+    expect(res2.message).to.eq("second");
   });
 });

--- a/tests/grpc/agent.spec.ts
+++ b/tests/grpc/agent.spec.ts
@@ -1,0 +1,86 @@
+import * as grpc from "@grpc/grpc-js";
+
+import { EchoResponse, startGrpcServer, stopGrpcServer } from "./server";
+
+import { GrpcAgent } from "../../src/grpc/agent";
+import { GrpcRequestWrapper } from "../../src/grpc/wrapper";
+import { expect } from "chai";
+import path from "path";
+import { randomString } from "../helpers";
+
+const PROTO_PATH = path.join(__dirname, "test.proto");
+const agentConfig = { service: "test_service", scheme: "Test", secret: randomString(32) };
+
+let grpcServer: grpc.Server;
+let port: number;
+
+beforeAll(async () => {
+  [grpcServer, port] = await startGrpcServer();
+});
+
+afterAll(async () => {
+  await stopGrpcServer(grpcServer);
+});
+
+describe("GrpcAgent constructor", () => {
+  it("should throw when the service is not found in the proto", () => {
+    expect(
+      () =>
+        new GrpcAgent(agentConfig, {
+          address: `localhost:${port}`,
+          protoPath: PROTO_PATH,
+          service: "test.NonExistent"
+        })
+    ).to.throw(/NonExistent.+not found/);
+  });
+
+  it("should construct successfully with a valid service path", () => {
+    expect(
+      () =>
+        new GrpcAgent(agentConfig, {
+          address: `localhost:${port}`,
+          protoPath: PROTO_PATH,
+          service: "test.TestService"
+        })
+    ).to.not.throw();
+  });
+});
+
+describe("GrpcAgent#call", () => {
+  let agent: GrpcAgent;
+
+  beforeAll(() => {
+    agent = new GrpcAgent(agentConfig, {
+      address: `localhost:${port}`,
+      protoPath: PROTO_PATH,
+      service: "test.TestService"
+    });
+  });
+
+  it("should return a GrpcRequestWrapper", () => {
+    const wrapper = agent.call("Echo", { message: "hello" });
+    expect(wrapper).to.be.instanceOf(GrpcRequestWrapper);
+  });
+
+  it("should execute an RPC end-to-end", async () => {
+    const res = await agent.call("Echo", { message: "grpc-agent" }).do<EchoResponse>();
+    expect(res.message).to.eq("grpc-agent");
+  });
+
+  it("should execute an authenticated call end-to-end", async () => {
+    const res = await agent.call("Echo", { message: "auth-test" }).auth().do<EchoResponse>();
+    expect(res.authorization).to.match(/^Test\s.+/);
+  });
+
+  it("should execute a tracked call end-to-end", async () => {
+    const res = await agent.call("Echo", { message: "track-test" }).track().do<EchoResponse>();
+    expect(res.request_id).to.be.a("string").with.length(36);
+    expect(res.origin_service).to.eq(agentConfig.service);
+  });
+
+  it("should chain auth and track together", async () => {
+    const res = await agent.call("Echo", { message: "chained" }).auth().track().do<EchoResponse>();
+    expect(res.authorization).to.match(/^Test\s.+/);
+    expect(res.request_id).to.be.a("string").with.length(36);
+  });
+});

--- a/tests/grpc/errors.spec.ts
+++ b/tests/grpc/errors.spec.ts
@@ -1,0 +1,37 @@
+import * as grpc from "@grpc/grpc-js";
+
+import { GrpcError } from "../../src/grpc/errors";
+import { expect } from "chai";
+
+function makeServiceError(code: grpc.status, details: string): grpc.ServiceError {
+  return Object.assign(new Error(details), {
+    code,
+    details,
+    metadata: new grpc.Metadata()
+  }) as grpc.ServiceError;
+}
+
+describe("GrpcError", () => {
+  it("should be an instance of Error", () => {
+    const err = new GrpcError("users", "GetUser", makeServiceError(grpc.status.NOT_FOUND, "not found"));
+    expect(err).to.be.instanceOf(Error);
+    expect(err).to.be.instanceOf(GrpcError);
+  });
+
+  it("should expose the gRPC status code", () => {
+    const err = new GrpcError("users", "GetUser", makeServiceError(grpc.status.NOT_FOUND, "not found"));
+    expect(err.code).to.eq(grpc.status.NOT_FOUND);
+  });
+
+  it("should expose the error details", () => {
+    const err = new GrpcError("users", "GetUser", makeServiceError(grpc.status.INVALID_ARGUMENT, "bad input"));
+    expect(err.details).to.eq("bad input");
+  });
+
+  it("should include service, method, status name, and details in the message", () => {
+    const err = new GrpcError("users", "CreateUser", makeServiceError(grpc.status.ALREADY_EXISTS, "email taken"));
+    expect(err.message).to.include("users/CreateUser");
+    expect(err.message).to.include("ALREADY_EXISTS");
+    expect(err.message).to.include("email taken");
+  });
+});

--- a/tests/grpc/server.ts
+++ b/tests/grpc/server.ts
@@ -1,0 +1,62 @@
+import * as grpc from "@grpc/grpc-js";
+import * as protoLoader from "@grpc/proto-loader";
+
+import path from "path";
+
+const PROTO_PATH = path.join(__dirname, "test.proto");
+
+const packageDef = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+});
+
+const proto = grpc.loadPackageDefinition(packageDef) as any;
+
+export interface EchoResponse {
+  message: string;
+  authorization: string;
+  request_id: string;
+  origin_service: string;
+}
+
+function echoHandler(call: grpc.ServerUnaryCall<any, any>, callback: grpc.sendUnaryData<any>) {
+  const meta = call.metadata;
+  callback(null, {
+    message: call.request.message,
+    authorization: (meta.get("authorization")[0] as string) ?? "",
+    request_id: (meta.get("x-request-id")[0] as string) ?? "",
+    origin_service: (meta.get("x-origin-service")[0] as string) ?? ""
+  });
+}
+
+function failHandler(_call: grpc.ServerUnaryCall<any, any>, callback: grpc.sendUnaryData<any>) {
+  const err = Object.assign(new Error("intentional failure"), {
+    code: grpc.status.INVALID_ARGUMENT,
+    details: "intentional failure",
+    metadata: new grpc.Metadata()
+  }) as grpc.ServiceError;
+  callback(err, null);
+}
+
+export function startGrpcServer(): Promise<[grpc.Server, number]> {
+  return new Promise((resolve, reject) => {
+    const server = new grpc.Server();
+    server.addService(proto.test.TestService.service, { Echo: echoHandler, Fail: failHandler });
+    server.bindAsync("0.0.0.0:0", grpc.ServerCredentials.createInsecure(), (err, port) => {
+      if (err) return reject(err);
+      resolve([server, port]);
+    });
+  });
+}
+
+export function stopGrpcServer(server: grpc.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.tryShutdown(err => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}

--- a/tests/grpc/test.proto
+++ b/tests/grpc/test.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package test;
+
+service TestService {
+  rpc Echo (EchoRequest) returns (EchoResponse);
+  rpc Fail (EchoRequest) returns (EchoResponse);
+}
+
+message EchoRequest {
+  string message = 1;
+}
+
+message EchoResponse {
+  string message       = 1;
+  string authorization = 2;
+  string request_id    = 3;
+  string origin_service = 4;
+}

--- a/tests/grpc/wrapper.spec.ts
+++ b/tests/grpc/wrapper.spec.ts
@@ -1,16 +1,15 @@
 import * as grpc from "@grpc/grpc-js";
-import * as jwt from "../../src/http/jwt";
 import * as protoLoader from "@grpc/proto-loader";
-
-import { EchoResponse, startGrpcServer, stopGrpcServer } from "./server";
 import chai, { expect } from "chai";
-
-import { GrpcError } from "../../src/grpc/errors";
-import { GrpcRequestWrapper } from "../../src/grpc/wrapper";
 import chaiAsPromised from "chai-as-promised";
 import path from "path";
-import { randomString } from "../helpers";
 import { v4 as uuidv4 } from "uuid";
+
+import * as jwt from "../../src/http/jwt";
+import { GrpcError } from "../../src/grpc/errors";
+import { GrpcRequestWrapper, StubResolver } from "../../src/grpc/wrapper";
+import { randomString } from "../helpers";
+import { EchoResponse, startGrpcServer, stopGrpcServer } from "./server";
 
 chai.use(chaiAsPromised);
 
@@ -21,11 +20,13 @@ const authConfig = { secret, scheme, timeout: "10s" };
 const service = "test_service";
 
 let grpcServer: grpc.Server;
-let stub: any;
+let serverAddress: string;
+let resolver: StubResolver;
 
 beforeAll(async () => {
   let port: number;
   [grpcServer, port] = await startGrpcServer();
+  serverAddress = `localhost:${port}`;
 
   const packageDef = protoLoader.loadSync(PROTO_PATH, {
     keepCase: true,
@@ -35,38 +36,60 @@ beforeAll(async () => {
     oneofs: true
   });
   const proto = grpc.loadPackageDefinition(packageDef) as any;
-  stub = new proto.test.TestService(`localhost:${port}`, grpc.credentials.createInsecure());
+  const stub = new proto.test.TestService(serverAddress, grpc.credentials.createInsecure());
+  // resolver always returns the pre-built stub so wrapper tests stay focused
+  // on wrapper behaviour and don't exercise stub caching
+  resolver = () => stub;
 });
 
 afterAll(async () => {
   await stopGrpcServer(grpcServer);
 });
 
+/** Convenience: wrapper that already has .via() set for the Echo method. */
+function echo(msg: string) {
+  return new GrpcRequestWrapper(resolver, service, authConfig, "Echo", { message: msg }).via(
+    serverAddress,
+    PROTO_PATH,
+    "test.TestService"
+  );
+}
+
+/** Convenience: wrapper that already has .via() set for the Fail method. */
+function fail() {
+  return new GrpcRequestWrapper(resolver, service, authConfig, "Fail", { message: "" }).via(
+    serverAddress,
+    PROTO_PATH,
+    "test.TestService"
+  );
+}
+
+describe("GrpcRequestWrapper#via", () => {
+  it("should throw when .do() is called without .via()", async () => {
+    const wrapper = new GrpcRequestWrapper(resolver, service, authConfig, "Echo", { message: "hello" });
+    await expect(wrapper.do()).to.be.rejectedWith(/No connection specified/);
+  });
+});
+
 describe("GrpcRequestWrapper#auth", () => {
   it("should forward the authorization header from an Express request", async () => {
     const token = randomString(32);
     const req: any = { headers: { authorization: `Bearer ${token}` } };
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
 
-    const res = await wrapper.auth(req).do<EchoResponse>();
+    const res = await echo("hello").auth(req).do<EchoResponse>();
 
     expect(res.authorization).to.eq(`Bearer ${token}`);
   });
 
-  it("should send no authorization when Express request has no header", async () => {
+  it("should throw when an Express request has no authorization header", () => {
     const req: any = { headers: {} };
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
-
-    const res = await wrapper.auth(req).do<EchoResponse>();
-
-    expect(res.authorization).to.eq("");
+    expect(() => echo("hello").auth(req)).to.throw(/requires an authorization token/);
   });
 
   it("should generate a JWT from a session object", async () => {
     const session = { user_id: "abc123", role: "admin" };
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
 
-    const res = await wrapper.auth(session).do<EchoResponse>();
+    const res = await echo("hello").auth(session).do<EchoResponse>();
 
     expect(res.authorization).to.match(new RegExp(`^${scheme}\\s.+`));
     const [, token] = res.authorization.split(" ");
@@ -76,9 +99,7 @@ describe("GrpcRequestWrapper#auth", () => {
   });
 
   it("should generate a default system JWT when called with no args", async () => {
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
-
-    const res = await wrapper.auth().do<EchoResponse>();
+    const res = await echo("hello").auth().do<EchoResponse>();
 
     expect(res.authorization).to.match(new RegExp(`^${scheme}\\s.+`));
     const [, token] = res.authorization.split(" ");
@@ -92,18 +113,15 @@ describe("GrpcRequestWrapper#track", () => {
   it("should forward x-request-id from an Express request", async () => {
     const requestId = uuidv4();
     const req: any = { headers: { "x-request-id": requestId } };
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
 
-    const res = await wrapper.track(req).do<EchoResponse>();
+    const res = await echo("hello").track(req).do<EchoResponse>();
 
     expect(res.request_id).to.eq(requestId);
     expect(res.origin_service).to.eq(service);
   });
 
   it("should generate a new UUID when called without a request", async () => {
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
-
-    const res = await wrapper.track().do<EchoResponse>();
+    const res = await echo("hello").track().do<EchoResponse>();
 
     expect(res.request_id).to.be.a("string").with.length(36);
     expect(res.origin_service).to.eq(service);
@@ -112,9 +130,7 @@ describe("GrpcRequestWrapper#track", () => {
 
 describe("GrpcRequestWrapper#set", () => {
   it("should attach arbitrary metadata without affecting the response", async () => {
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
-
-    const res = await wrapper.set("x-custom", "value").do<EchoResponse>();
+    const res = await echo("hello").set("x-custom", "value").do<EchoResponse>();
 
     expect(res.message).to.eq("hello");
   });
@@ -122,25 +138,19 @@ describe("GrpcRequestWrapper#set", () => {
 
 describe("GrpcRequestWrapper#do", () => {
   it("should execute the RPC and return the typed response", async () => {
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "ping" });
-
-    const res = await wrapper.do<EchoResponse>();
+    const res = await echo("ping").do<EchoResponse>();
 
     expect(res.message).to.eq("ping");
   });
 
   it("should reject with GrpcError on a server-side error", async () => {
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Fail", { message: "hello" });
-
-    await expect(wrapper.do()).to.be.rejectedWith(GrpcError);
+    await expect(fail().do()).to.be.rejectedWith(GrpcError);
   });
 
   it("should surface the correct code and details in GrpcError", async () => {
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Fail", { message: "hello" });
-
     let err: GrpcError | undefined;
     try {
-      await wrapper.do();
+      await fail().do();
     } catch (e) {
       err = e as GrpcError;
     }
@@ -150,10 +160,7 @@ describe("GrpcRequestWrapper#do", () => {
     expect(err!.details).to.eq("intentional failure");
   });
 
-  it("should respect the deadline and reject with a timeout error", async function () {
-    // Use a 0-second deadline — the call cannot complete that fast
-    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "slow" });
-
-    await expect(wrapper.do(0)).to.be.rejectedWith(GrpcError);
+  it("should respect the deadline and reject with a timeout error", async () => {
+    await expect(echo("slow").do(0)).to.be.rejectedWith(GrpcError);
   });
 });

--- a/tests/grpc/wrapper.spec.ts
+++ b/tests/grpc/wrapper.spec.ts
@@ -1,0 +1,159 @@
+import * as grpc from "@grpc/grpc-js";
+import * as jwt from "../../src/http/jwt";
+import * as protoLoader from "@grpc/proto-loader";
+
+import { EchoResponse, startGrpcServer, stopGrpcServer } from "./server";
+import chai, { expect } from "chai";
+
+import { GrpcError } from "../../src/grpc/errors";
+import { GrpcRequestWrapper } from "../../src/grpc/wrapper";
+import chaiAsPromised from "chai-as-promised";
+import path from "path";
+import { randomString } from "../helpers";
+import { v4 as uuidv4 } from "uuid";
+
+chai.use(chaiAsPromised);
+
+const PROTO_PATH = path.join(__dirname, "test.proto");
+const secret = new TextEncoder().encode(randomString(32));
+const scheme = "Test";
+const authConfig = { secret, scheme, timeout: "10s" };
+const service = "test_service";
+
+let grpcServer: grpc.Server;
+let stub: any;
+
+beforeAll(async () => {
+  let port: number;
+  [grpcServer, port] = await startGrpcServer();
+
+  const packageDef = protoLoader.loadSync(PROTO_PATH, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true
+  });
+  const proto = grpc.loadPackageDefinition(packageDef) as any;
+  stub = new proto.test.TestService(`localhost:${port}`, grpc.credentials.createInsecure());
+});
+
+afterAll(async () => {
+  await stopGrpcServer(grpcServer);
+});
+
+describe("GrpcRequestWrapper#auth", () => {
+  it("should forward the authorization header from an Express request", async () => {
+    const token = randomString(32);
+    const req: any = { headers: { authorization: `Bearer ${token}` } };
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
+
+    const res = await wrapper.auth(req).do<EchoResponse>();
+
+    expect(res.authorization).to.eq(`Bearer ${token}`);
+  });
+
+  it("should send no authorization when Express request has no header", async () => {
+    const req: any = { headers: {} };
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
+
+    const res = await wrapper.auth(req).do<EchoResponse>();
+
+    expect(res.authorization).to.eq("");
+  });
+
+  it("should generate a JWT from a session object", async () => {
+    const session = { user_id: "abc123", role: "admin" };
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
+
+    const res = await wrapper.auth(session).do<EchoResponse>();
+
+    expect(res.authorization).to.match(new RegExp(`^${scheme}\\s.+`));
+    const [, token] = res.authorization.split(" ");
+    const decoded = await jwt.decode(secret, token);
+    expect(decoded.user_id).to.eq(session.user_id);
+    expect(decoded.role).to.eq(session.role);
+  });
+
+  it("should generate a default system JWT when called with no args", async () => {
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
+
+    const res = await wrapper.auth().do<EchoResponse>();
+
+    expect(res.authorization).to.match(new RegExp(`^${scheme}\\s.+`));
+    const [, token] = res.authorization.split(" ");
+    const decoded = await jwt.decode(secret, token);
+    expect(decoded.service).to.eq(service);
+    expect(Date.parse(decoded.request_time)).to.not.be.NaN;
+  });
+});
+
+describe("GrpcRequestWrapper#track", () => {
+  it("should forward x-request-id from an Express request", async () => {
+    const requestId = uuidv4();
+    const req: any = { headers: { "x-request-id": requestId } };
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
+
+    const res = await wrapper.track(req).do<EchoResponse>();
+
+    expect(res.request_id).to.eq(requestId);
+    expect(res.origin_service).to.eq(service);
+  });
+
+  it("should generate a new UUID when called without a request", async () => {
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
+
+    const res = await wrapper.track().do<EchoResponse>();
+
+    expect(res.request_id).to.be.a("string").with.length(36);
+    expect(res.origin_service).to.eq(service);
+  });
+});
+
+describe("GrpcRequestWrapper#set", () => {
+  it("should attach arbitrary metadata without affecting the response", async () => {
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "hello" });
+
+    const res = await wrapper.set("x-custom", "value").do<EchoResponse>();
+
+    expect(res.message).to.eq("hello");
+  });
+});
+
+describe("GrpcRequestWrapper#do", () => {
+  it("should execute the RPC and return the typed response", async () => {
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "ping" });
+
+    const res = await wrapper.do<EchoResponse>();
+
+    expect(res.message).to.eq("ping");
+  });
+
+  it("should reject with GrpcError on a server-side error", async () => {
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Fail", { message: "hello" });
+
+    await expect(wrapper.do()).to.be.rejectedWith(GrpcError);
+  });
+
+  it("should surface the correct code and details in GrpcError", async () => {
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Fail", { message: "hello" });
+
+    let err: GrpcError | undefined;
+    try {
+      await wrapper.do();
+    } catch (e) {
+      err = e as GrpcError;
+    }
+
+    expect(err).to.be.instanceOf(GrpcError);
+    expect(err!.code).to.eq(grpc.status.INVALID_ARGUMENT);
+    expect(err!.details).to.eq("intentional failure");
+  });
+
+  it("should respect the deadline and reject with a timeout error", async function () {
+    // Use a 0-second deadline — the call cannot complete that fast
+    const wrapper = new GrpcRequestWrapper(stub, service, authConfig, "Echo", { message: "slow" });
+
+    await expect(wrapper.do(0)).to.be.rejectedWith(GrpcError);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,6 +505,24 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
   integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
 
+"@grpc/grpc-js@^1.14.3":
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.3.tgz#4c9b817a900ae4020ddc28515ae4b52c78cfb8da"
+  integrity sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==
+  dependencies:
+    "@grpc/proto-loader" "^0.8.0"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.0.tgz#b6c324dd909c458a0e4aa9bfd3d69cf78a4b9bd8"
+  integrity sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.5.3"
+    yargs "^17.7.2"
+
 "@ioredis/commands@^1.1.1":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
@@ -784,6 +802,64 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
 "@sinclair/typebox@^0.24.1":
   version "0.24.28"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.28.tgz#15aa0b416f82c268b1573ab653e4413c965fe794"
@@ -1033,6 +1109,13 @@
   version "16.7.6"
   resolved "https://registry.npmjs.org/@types/node/-/node-16.7.6.tgz"
   integrity sha512-VESVNFoa/ahYA62xnLBjo5ur6gPsgEE5cNRy8SrdnkZ2nwJSW0kJ4ufbFr2zuU9ALtHM8juY53VcRoTA7htXSg==
+
+"@types/node@>=13.7.0":
+  version "25.5.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.5.2.tgz#94861e32f9ffd8de10b52bbec403465c84fff762"
+  integrity sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==
+  dependencies:
+    undici-types "~7.18.0"
 
 "@types/node@^18.11.18":
   version "18.11.18"
@@ -1471,6 +1554,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 cluster-key-slot@^1.1.0:
@@ -2576,6 +2668,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
@@ -2600,6 +2697,11 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+long@^5.0.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 loupe@^2.3.1:
   version "2.3.4"
@@ -3006,6 +3108,24 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+protobufjs@^7.5.3:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
+  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -3498,6 +3618,11 @@ typescript@^4.9.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
@@ -3614,7 +3739,7 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@^21.0.0, yargs-parser@^21.0.1:
+yargs-parser@^21.0.0, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
@@ -3631,6 +3756,19 @@ yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Summary

Adds a gRPC client to `octonet` that mirrors the existing `HttpAgent`/`RequestWrapper` pattern, so services can choose between HTTP and gRPC with a consistent interface.

- **`GrpcAgent`** accepts only auth config at construction time — the same way `HttpAgent` works. The target service address, proto file, and service name are specified per-call via `.via()`, keeping a single agent instance reusable across any number of downstream gRPC services.
- **Lazy stub caching** — gRPC stubs are created on the first call to a given `(address, protoPath, service)` combination and reused for every subsequent call. Proto-loading and channel-creation overhead is paid at most once per unique connection target.

---

## Usage

```ts
// One-time setup — just auth config, like HttpAgent
const grpcAgent = new GrpcAgent({
  service: "rise-moneyio",
  scheme: env.auth_scheme,
  secret: env.service_secret,
});

// Call site — connection info lives here
const user = await grpcAgent
  .call("GetUser", { id })
  .via(env.users_grpc_url, path.join(__dirname, "user.proto"), "users.UserService")
  .auth(req)   // forward Authorization header from an Express request
  .track(req)  // forward x-request-id; set x-origin-service
  .do<User>(60);
```

---

## New exports

| Export | Description |
|---|---|
| `GrpcAgent` | Configure once, call any gRPC service via `.via()` |
| `GrpcRequestWrapper` | Fluent builder — `.via()`, `.auth()`, `.track()`, `.set()`, `.do()` |
| `StubResolver` | Type for the stub factory callback (useful for testing) |
| `GrpcError` | Thrown on non-OK status; exposes `.code` and `.details` |

---

## Tests

Integration tests start a real in-process gRPC server bound to a random port — no mocks.

- **`GrpcError`** — message format, status code, details
- **`GrpcRequestWrapper`** — missing `.via()` guard, all three `auth()` modes, `track()` with and without a source request, `set()`, `do()` success / error / deadline
- **`GrpcAgent`** — lazy construction, invalid service path rejected at `.do()` time, end-to-end calls with auth and tracking chained, stub caching verified under concurrent calls

---

## Checklist

- [x] `@grpc/grpc-js` and `@grpc/proto-loader` added to `dependencies`
- [x] Exported from the package root via `src/index.ts`
- [x] 24 new tests, all passing — full suite green (139 tests)
