### PR TITLE
fix: sanitize request headers in expressRequest serializer

### DIFF
--- a/src/logging/serializers.ts
+++ b/src/logging/serializers.ts
@@ -127,7 +127,7 @@ export function expressRequest(...paths: string[]): (req: Request) => object {
     const log = {
       method: req.method,
       url: req.url,
-      headers: deepSanitizeObj(req.headers as object, ...paths),
+      headers: deepSanitizeObj(req.headers as object, ...paths.map(p => p.toLowerCase())),
       params: req.params,
       remoteAddress: req.socket.remoteAddress,
       remotePort: req.socket.remotePort

--- a/src/logging/serializers.ts
+++ b/src/logging/serializers.ts
@@ -127,7 +127,7 @@ export function expressRequest(...paths: string[]): (req: Request) => object {
     const log = {
       method: req.method,
       url: req.url,
-      headers: req.headers,
+      headers: deepSanitizeObj(req.headers as object, ...paths),
       params: req.params,
       remoteAddress: req.socket.remoteAddress,
       remotePort: req.socket.remotePort

--- a/src/logging/serializers.ts
+++ b/src/logging/serializers.ts
@@ -19,6 +19,7 @@ export function defaultSerializers(...paths: string[]) {
     req: expressRequest(...paths),
     res: expressResponse(...paths),
     event: sanitized(...paths),
+    data: sanitized(...paths),
     err: serializeErr
   };
 }

--- a/tests/logging/logging.spec.ts
+++ b/tests/logging/logging.spec.ts
@@ -200,6 +200,25 @@ describe("Bunyan#httpError", () => {
   });
 });
 
+describe("Bunyan#DataPayload", () => {
+  it("should strip sensitive fields from data logs", () => {
+    const dataBuf = new Bunyan.RingBuffer({ limit: 5 });
+    const dataLogger = new Logger({
+      name: "data_payload_test",
+      buffer: dataBuf,
+      serializers: defaultSerializers("bvn", "phone_number", "account_number")
+    });
+
+    dataLogger.log({ data: { bvn: "12345678901", phone_number: "08012345678", account_number: "0123456789", name: "John Doe" } });
+
+    const record = dataBuf.records[0];
+    expect(record.data).to.not.have.property("bvn");
+    expect(record.data).to.not.have.property("phone_number");
+    expect(record.data).to.not.have.property("account_number");
+    expect(record.data).to.have.property("name");
+  });
+});
+
 describe("Bunyan#AxiosRequest", () => {
   it("should strip sensitive headers from axios_req logs", () => {
     const axiosBuf = new Bunyan.RingBuffer({ limit: 5 });

--- a/tests/logging/logging.spec.ts
+++ b/tests/logging/logging.spec.ts
@@ -10,7 +10,7 @@ const ringbuffer = new Bunyan.RingBuffer({ limit: 5 });
 const logger = new Logger({
   name: "logger_tests",
   buffer: ringbuffer,
-  serializers: defaultSerializers("admin.password", "password")
+  serializers: defaultSerializers("admin.password", "password", "authorization", "x-webhook-secret")
 });
 
 const mockProvider: TracingProvider = {
@@ -109,6 +109,15 @@ describe("Bunyan#Request", () => {
     expect(properties).to.have.property("req");
     expect(properties.req.body).to.not.have.property("password");
     expect(properties.req.body).to.have.property("other_prop");
+  });
+
+  it("should ensure sensitive headers are not logged on request", async () => {
+    await axios.post(`${baseUrl}/req`, {}, { headers: { password: "secret", Authorization: "Bearer token", "x-webhook-secret": "whsec_abc" } });
+    const properties = ringbuffer.records[0];
+    expect(properties.req.headers).to.not.have.property("password");
+    expect(properties.req.headers).to.not.have.property("authorization");
+    expect(properties.req.headers).to.not.have.property("x-webhook-secret");
+    expect(properties.req.headers).to.have.property("content-type");
   });
 });
 

--- a/tests/logging/logging.spec.ts
+++ b/tests/logging/logging.spec.ts
@@ -10,7 +10,7 @@ const ringbuffer = new Bunyan.RingBuffer({ limit: 5 });
 const logger = new Logger({
   name: "logger_tests",
   buffer: ringbuffer,
-  serializers: defaultSerializers("admin.password", "password", "authorization", "x-webhook-secret")
+  serializers: defaultSerializers("admin.password", "password", "Authorization", "X-Webhook-Secret")
 });
 
 const mockProvider: TracingProvider = {


### PR DESCRIPTION
- We use axios by default in our httpAgent which serializes sensitive information through axiosRequest. That was done [here](https://github.com/risevest/octonet/pull/129). This ensures sensitive information in the header and body are not logged.
- Some providers send webhooks with sensitive information in their headers such as plain webhook secrets. When these are received, our middleware logger logs this through the `request.logging.ts` file which calls Octonet's `logger.request(req);`
- The middleware then passes the header as received and logs it using the `expressRequest` method without redacting sensitive information
- This PR ensures that the items already listed in the defaultSerializers are also redacted from the logs when passed through the `expressRequest` method
- AMQP and NATS worker handlers log decoded message payloads under the data key. The default serializer does not cover the data key and does not get sanitized before logging. Added this to handler consumers for amqp and nats