### PR TITLE
feat: Add warn method to Logger and tests

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -136,6 +136,27 @@ export class Logger {
   }
 
   /**
+   * Log a warning
+   * @param metadata data to be logged
+   */
+  warn(metadata: object): void;
+  /**
+   * Log a warning with a message
+   * @param message message to be logged
+   * @param metadata data to be logged
+   */
+  warn(message: string, metadata?: object): void;
+  warn(entry: string | any, metadata?: object) {
+    if (typeof entry === "string" && metadata) {
+      this.logger.warn(this.withTrace(metadata), entry);
+    } else if (typeof entry === "string") {
+      this.logger.warn(this.withTrace({}), entry);
+    } else {
+      this.logger.warn(this.withTrace(entry));
+    }
+  }
+
+  /**
    * Log internal application error
    * @param err actual error being logged
    * @param extras anything else to log with the error

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -146,7 +146,7 @@ export class Logger {
    * @param metadata data to be logged
    */
   warn(message: string, metadata?: object): void;
-  warn(entry: string | any, metadata?: object) {
+  warn(...args: [metadata: object] | [message: string, metadata?: object]) {
     if (typeof entry === "string" && metadata) {
       this.logger.warn(this.withTrace(metadata), entry);
     } else if (typeof entry === "string") {

--- a/tests/logging/logging.spec.ts
+++ b/tests/logging/logging.spec.ts
@@ -219,6 +219,35 @@ describe("Bunyan#DataPayload", () => {
   });
 });
 
+describe("Bunyan#warn", () => {
+  it("should log a warning with an object", () => {
+    logger.warn({ message: "low balance", threshold: 100 });
+    const record = ringbuffer.records[0];
+    expect(ringbuffer.records).to.be.length(1);
+    expect(record).to.have.property("message", "low balance");
+    expect(record).to.have.property("threshold", 100);
+    expect(record.level).to.equal(40); // Bunyan WARN level
+  });
+
+  it("should log a warning with a string message only", () => {
+    logger.warn("something looks off");
+    const record = ringbuffer.records[0];
+    expect(ringbuffer.records).to.be.length(1);
+    expect(record.msg).to.equal("something looks off");
+    expect(record.level).to.equal(40);
+  });
+
+  it("should log a warning with a string message and metadata", () => {
+    logger.warn("fallback used", { provider: "faida_v2", reason: "primary timeout" });
+    const record = ringbuffer.records[0];
+    expect(ringbuffer.records).to.be.length(1);
+    expect(record.msg).to.equal("fallback used");
+    expect(record).to.have.property("provider", "faida_v2");
+    expect(record).to.have.property("reason", "primary timeout");
+    expect(record.level).to.equal(40);
+  });
+});
+
 describe("Bunyan#AxiosRequest", () => {
   it("should strip sensitive headers from axios_req logs", () => {
     const axiosBuf = new Bunyan.RingBuffer({ limit: 5 });
@@ -273,6 +302,31 @@ describe("Logger#tracing", () => {
 
     it("should inject trace context on string-only log", () => {
       tracedLogger.log("just a string");
+      const record = traceBuffer.records[0];
+      expect(record).to.have.property("trace_id", "abc123");
+      expect(record).to.have.property("span_id", "def456");
+    });
+  });
+
+  describe("warn()", () => {
+    it("should inject trace_id and span_id on object warn", () => {
+      tracedLogger.warn({ message: "degraded" });
+      const record = traceBuffer.records[0];
+      expect(record).to.have.property("trace_id", "abc123");
+      expect(record).to.have.property("span_id", "def456");
+      expect(record).to.have.property("message", "degraded");
+    });
+
+    it("should inject trace context on string warn with metadata", () => {
+      tracedLogger.warn("fallback triggered", { service: "faida_v2" });
+      const record = traceBuffer.records[0];
+      expect(record).to.have.property("trace_id", "abc123");
+      expect(record).to.have.property("span_id", "def456");
+      expect(record).to.have.property("service", "faida_v2");
+    });
+
+    it("should inject trace context on string-only warn", () => {
+      tracedLogger.warn("cache miss");
       const record = traceBuffer.records[0];
       expect(record).to.have.property("trace_id", "abc123");
       expect(record).to.have.property("span_id", "def456");


### PR DESCRIPTION
Implement Logger.warn overloads in src/logging/logger.ts to support object-only, string-only, and string+metadata calls (injects trace context via withTrace and forwards to Bunyan WARN). Add comprehensive tests in tests/logging/logging.spec.ts covering object logging, string-only messages, string+metadata, and trace context injection for warned entries (expects Bunyan WARN level 40).